### PR TITLE
调整__follow里面对anchor可见性的判断方式

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,17 +1,17 @@
 {
-  "name": "popupjs",
+  "name": "a-popupjs",
   "version": "1.0.0",
   "readmeFilename": "README.md",
   "description": "W3C HTML5 Dialog Plus",
-  "homepage": "https://github.com/aui/popupjs",
+  "homepage": "https://github.com/shuizhongyueming/a-popupjs",
   "keywords": [
     "dialog",
     "popup"
   ],
-  "author": "aui",
+  "author": "shuizhongyueming@gmail.com",
   "repository": {
     "type": "git",
-    "url": "https://github.com/aui/popupjs.git"
+    "url": "https://github.com/shuizhongyueming/a-popupjs.git"
   },
   "main": "./src/popup.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a-popupjs",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "readmeFilename": "README.md",
   "description": "W3C HTML5 Dialog Plus",
   "homepage": "https://github.com/shuizhongyueming/a-popupjs",

--- a/src/popup.js
+++ b/src/popup.js
@@ -485,8 +485,7 @@ $.extend(Popup.prototype, {
 
         // 隐藏元素不可用
         if ($elem) {
-            var o = $elem.offset();
-            if (o.left * o.top < 0) {
+            if ($elem.is(':hidden')) {
                 return this.__center();
             }
         }

--- a/src/popup.js
+++ b/src/popup.js
@@ -137,6 +137,12 @@ $.extend(Popup.prototype, {
     // 是否显示为模态框
     modal: false,
 
+    // 是否在无法完整展现弹窗的时候居中展现弹窗
+    isCenterForFallback: true,
+
+    // 是否开启debug模式[最好只在测试的时候开启]
+    debug: false,
+
     /**
      * 显示浮层
      * @param   {HTMLElement, Event}  指定位置（可选）
@@ -396,6 +402,13 @@ $.extend(Popup.prototype, {
         return this;
     },
 
+    // log
+    __log: function(){
+        if (this.debug && console && console.log) {
+            console.log.apply(console, arguments);
+        }
+    },
+
 
     // 获取事件缓存
     __getEventListener: function (type) {
@@ -482,14 +495,6 @@ $.extend(Popup.prototype, {
             popup.removeClass(this.__followSkin);
         }
 
-
-        // 隐藏元素不可用
-        if ($elem) {
-            if ($elem.is(':hidden')) {
-                return this.__center();
-            }
-        }
-        
         var that = this;
         var fixed = this.fixed;
 
@@ -586,6 +591,19 @@ $.extend(Popup.prototype, {
         
         css[name[align[0]]] = parseInt(temp[0][align[0]]);
         css[name[align[1]]] = parseInt(temp[1][align[1]]);
+
+        /**
+         * 在弹窗的最终定位里面
+         * 如果有值小于0，则弹窗无法完整展现在视窗里面
+         * 此时应该居中展现之
+         */
+        for (var prop in css) {
+            if (css.hasOwnProperty(prop) && css[prop] < 0 && this.isCenterForFallback) {
+                this.__log('Popup: the popup can show all in the viewport, so center it as fallback');
+                return this.__center();
+            }
+        }
+
         popup.css(css);
 
     },

--- a/src/popup.js
+++ b/src/popup.js
@@ -104,35 +104,38 @@ $.extend(Popup.prototype, {
      * @event
      */
 
-    /** 浮层 DOM 素节点[*] */
+    // 浮层 DOM 素节点[*] 
     node: null,
 
-    /** 遮罩 DOM 节点[*] */
+    // 遮罩 DOM 节点[*] 
     backdrop: null,
 
-    /** 是否开启固定定位[*] */
+    // 是否开启固定定位[*] 
     fixed: false,
 
-    /** 判断对话框是否删除[*] */
+    // 判断对话框是否删除[*] 
     destroyed: true,
 
-    /** 判断对话框是否显示 */
+    // 判断对话框是否显示 
     open: false,
 
-    /** close 返回值 */
+    // close 返回值 
     returnValue: '',
 
-    /** 是否自动聚焦 */
+    // 是否自动聚焦 
     autofocus: true,
 
-    /** 对齐方式[*] */
+    // 对齐方式[*] 
     align: 'bottom left',
 
-    /** 内部的 HTML 字符串 */
+    // 内部的 HTML 字符串 
     innerHTML: '',
 
-    /** CSS 类名 */
+    // CSS 类名 
     className: 'ui-popup',
+
+    // 是否显示为模态框
+    modal: false,
 
     /**
      * 显示浮层

--- a/test/visible.html
+++ b/test/visible.html
@@ -1,0 +1,106 @@
+<!doctype html>
+<html lang="zh">
+<head>
+	<meta charset="UTF-8">
+	<title>test</title>
+
+	<style>
+	.ui-dialog {
+		padding: 20px;
+	    *zoom:1;
+	    _float: left;
+	    position: relative;
+	    background-color: #FFF;
+	    border: 1px solid #999;
+	    outline: 0;
+	    background-clip: padding-box;
+	    font-family: Helvetica, arial, sans-serif;
+	    font-size: 14px;
+	    line-height: 1.428571429;
+	    color: #333;
+	    opacity: 0;
+	    -webkit-transform: scale(0);
+	    transform: scale(0);
+	    -webkit-transition: -webkit-transform .15s ease-in-out, opacity .15s ease-in-out;
+	    transition: transform .15s ease-in-out, opacity .15s ease-in-out;
+	}
+	.ui-popup-show .ui-dialog {
+	    opacity: 1;
+	    -webkit-transform: scale(1);
+	    transform: scale(1);
+	}
+	.ui-popup-focus .ui-dialog {
+	    box-shadow: 0 0 8px rgba(0, 0, 0, 0.1);
+	}
+
+    #visible, #hidden, #out-viewport, #half-viewport{
+        width: 400px;
+        height: 200px;
+        border: 1px solid #ccc;
+        text-align: center;
+        line-height: 200px;
+        margin-top: 100px;
+        margin-left: 500px;
+    }
+    #hidden{
+        display: none;
+    }
+    #out-viewport{
+        margin-top: 1400px;
+    }
+    #half-viewport{
+        position: absolute;
+        right: -200px;
+        top: 200px;
+        margin: 0;
+    }
+	</style>
+</head>
+<body>
+
+
+<button id="show-at-visible" t="visible">show at visible div</button>
+<button id="show-at-hidden" t="hidden">show at hidden div</button>
+<button id="show-at-out-viewport" t="out-viewport">show at out viewport div</button>
+<button id="show-at-half-viewport" t="half-viewport">show at half out viewport div</button>
+
+
+<div id="visible">This is the visible div</div>
+<div id="hidden">This is the hidden div</div>
+<div id="out-viewport">This is the out viewport div</div>
+<div id="half-viewport">This is the half viewport div</div>
+
+
+<script src="../lib/sea.js"></script>
+<script>
+seajs.config({
+  alias: {
+    "jquery": "jquery-1.10.2.js"
+  }
+});
+</script>
+
+<script>
+seajs.use(['jquery', '../src/popup.js'], function ($, Popup) {
+
+	var dialog = function (anchor) {
+		var popup = new Popup();
+		popup.innerHTML =
+		 '<div class="ui-dialog">'
+		+	'<p>hello world</p>'
+		+	'<button id="dialog-close">close</button>'
+		+'</div>';
+		popup.show(anchor);
+
+		$('#dialog-close').one('click', function () {
+			popup.close().remove();
+		});
+	};
+
+    $('#show-at-visible').add('#show-at-hidden').add('#show-at-out-viewport').add('#show-at-half-viewport').on('click', function(e){
+        dialog( $('#'+$(this).attr('t'))[0] );
+    });
+});
+</script>
+</body>
+</html>

--- a/test/visible.html
+++ b/test/visible.html
@@ -54,6 +54,12 @@
         top: 200px;
         margin: 0;
     }
+    #top-out{
+        position: absolute;
+        top: -600px;
+        left: 0;
+        margin: 0;
+    }
 	</style>
 </head>
 <body>
@@ -62,6 +68,7 @@
 <button id="show-at-visible" t="visible">show at visible div</button>
 <button id="show-at-hidden" t="hidden">show at hidden div</button>
 <button id="show-at-out-viewport" t="out-viewport">show at out viewport div</button>
+<button id="show-at-top-out" t="top-out">show at out viewport div</button>
 <button id="show-at-half-viewport" t="half-viewport">show at half out viewport div</button>
 
 
@@ -69,6 +76,7 @@
 <div id="hidden">This is the hidden div</div>
 <div id="out-viewport">This is the out viewport div</div>
 <div id="half-viewport">This is the half viewport div</div>
+<div id="top-out">This is the top out div</div>
 
 
 <script src="../lib/sea.js"></script>
@@ -90,6 +98,7 @@ seajs.use(['jquery', '../src/popup.js'], function ($, Popup) {
 		+	'<p>hello world</p>'
 		+	'<button id="dialog-close">close</button>'
 		+'</div>';
+        popup.debug = true;
 		popup.show(anchor);
 
 		$('#dialog-close').one('click', function () {
@@ -97,7 +106,7 @@ seajs.use(['jquery', '../src/popup.js'], function ($, Popup) {
 		});
 	};
 
-    $('#show-at-visible').add('#show-at-hidden').add('#show-at-out-viewport').add('#show-at-half-viewport').on('click', function(e){
+    $('#show-at-visible').add('#show-at-hidden').add('#show-at-out-viewport').add('#show-at-half-viewport').add('#show-at-top-out').on('click', function(e){
         dialog( $('#'+$(this).attr('t'))[0] );
     });
 });


### PR DESCRIPTION
之前是用anchor的offset的left和top都不为0作为判断是否可见的依据。这
个判断方式有点不够严谨，因为一个元素的可见与否，与它的offset没有
直接关联的，应该相关联的属性是width和height是否都大于0。

所以改成使用jquery的:hidden选择器来进行判断。

同时新增了测试文件visible.html 用来测试anchor可见，不可见，在视窗
之外和一半在视窗之外，show(anchor)能否正常工作。